### PR TITLE
Labels should be in H3

### DIFF
--- a/templates/changelog.md
+++ b/templates/changelog.md
@@ -14,11 +14,11 @@ Changelog entries are classified using the following labels _(from [keep-a-chang
 
 This is an example section. Update this with actual history.
 
-**Changed**
+### Changed
 
 - Description of something that was changed.
 
-**Added**
+### Added
 
 - Description of something that was added.
 


### PR DESCRIPTION
According to [keep-a-changelog's answer](https://github.com/olivierlacan/keep-a-changelog/blob/v0.3.0/source/index.haml#L82), there is currently no standard changelog format. But he [encourages us](https://github.com/olivierlacan/keep-a-changelog/blob/v0.3.0/source/index.haml#L90) to follow [the original template](https://github.com/olivierlacan/keep-a-changelog/blob/v0.3.0/CHANGELOG.md). Therefore, I suggest we use H3 instead of Strong Emphasis
